### PR TITLE
fix GolangCI issue (errcheck and could not determine GOARCH and Go compiler)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   test:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
         environment:
           GO111MODULE: "on"
     working_directory: /go/src/github.com/po3rin/llb2dot

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llb2dot
 
-<img src="https://img.shields.io/badge/go-v1.11-blue.svg"/> [![CircleCI](https://circleci.com/gh/po3rin/llb2dot.svg?style=shield)](https://circleci.com/gh/po3rin/llb2dot) [![GolangCI](https://golangci.com/badges/github.com/po3rin/llb2dot.svg)](https://golangci.com) <a href="https://codeclimate.com/github/po3rin/llb2dot/maintainability"><img src="https://api.codeclimate.com/v1/badges/1bee242d3deb899654bf/maintainability" /></a>
+<img src="https://img.shields.io/badge/go-v1.13-blue.svg"/> [![CircleCI](https://circleci.com/gh/po3rin/llb2dot.svg?style=shield)](https://circleci.com/gh/po3rin/llb2dot) [![GolangCI](https://golangci.com/badges/github.com/po3rin/llb2dot.svg)](https://golangci.com) <a href="https://codeclimate.com/github/po3rin/llb2dot/maintainability"><img src="https://api.codeclimate.com/v1/badges/1bee242d3deb899654bf/maintainability" /></a>
 
 llb2dot package lets you to convert BuildKit LLB to dot language to analize. You also can directly load Dockerfile.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/po3rin/llb2dot
 
-go 1.12
+go 1.13
 
 require (
 	github.com/moby/buildkit v0.4.0

--- a/server/main.go
+++ b/server/main.go
@@ -11,7 +11,7 @@ func main() {
 	fs := http.FileServer(http.Dir("view"))
 	http.Handle("/", fs)
 	http.HandleFunc("/api/dot", Handler)
-	err := htta.ListenAndServe(":8080", nil)
+	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		log.Fatal("failed to listen 8080 port")
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/po3rin/llb2dot"
@@ -10,7 +11,10 @@ func main() {
 	fs := http.FileServer(http.Dir("view"))
 	http.Handle("/", fs)
 	http.HandleFunc("/api/dot", Handler)
-	http.ListenAndServe(":8080", nil)
+	err := htta.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal("failed to listen 8080 port")
+	}
 }
 
 // Handler handle request.


### PR DESCRIPTION
I fix issue #3

```
GOLANGCI_COM_RUN=1 golangci-lint run --out-format=json --issues-exit-code=0 --deadline=5m --new=false --new-from-rev= --new-from-patch=
    server/main.go:13: Error return value of `http.ListenAndServe` is not checked (errcheck)
```